### PR TITLE
Update README.md curl instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ chmod 755 /usr/local/bin/c2t-96h
 
 An alternative and perhaps simplier install for OS/X:
 ```
-sudo curl https://github.com/datajerk/c2t/raw/master/bin/c2t-96h >/usr/local/bin/c2t-96h
+sudo curl https://raw.githubusercontent.com/datajerk/c2t/master/bin/c2t-96h >/usr/local/bin/c2t-96h
 sudo chmod 755 /usr/local/bin/c2t-96h
-sudo curl https://github.com/datajerk/c2t/raw/master/bin/c2t-96h >/usr/local/bin/c2t
+sudo curl https://raw.githubusercontent.com/datajerk/c2t/master/bin/c2t >/usr/local/bin/c2t
 sudo chmod 755 /usr/local/bin/c2t
 ```
 


### PR DESCRIPTION
Github now has a redirect and new server for raw content. Using the curl -L flag would follow the redirect, but changing the url seemed like a better solution. Also there was a typo that was downloading c2t-96h 2 times, and renaming one c2t which could lead to unexpected user issues. 