### PR TITLE
Fix for hexdump parsing

### DIFF
--- a/makeheader
+++ b/makeheader
@@ -5,7 +5,7 @@ header()
 	FILE=$1
 	VAR=$2
 	EOL=$3
-	BYTES=$(hexdump -v $FILE | sed 's/^.......//' | wc -w | awk '{print $1}');
+	BYTES=$(hexdump -ve '1/1 "%.2x "' $FILE | wc -w | awk '{print $1}');
 
 	echo "/*"
 	expand ${FILE}.s
@@ -13,7 +13,7 @@ header()
 
 	printf "unsigned char $VAR[] = {\n\t"
 	
-	for i in $(hexdump -v $FILE | sed 's/^.......//');
+	for i in $(hexdump -ve '1/1 "%.2x "' $FILE);
 	do
 		printf "0x%02X" 0x$i
 		BYTES=$((BYTES - 1))


### PR DESCRIPTION
On my machine, makeheader produced headers with lots of casts of 16-bit variables to unsigned char. Compiler warned about this many times and then successfully produced executable files, which warn about simulated inflate failures and produce unusable WAV files. This little modification in how hexdump is called fixes it for me. I believe this is the same issue as https://github.com/datajerk/c2t/issues/1