### PR TITLE
Remove c2t.h.[12] after makeheader is done

### DIFF
--- a/makeheader
+++ b/makeheader
@@ -76,3 +76,5 @@ cat mon/dos33.boot2.mon | \
 echo "};" >>c2t.h.2
 
 cat c2t.h.[012] > c2t.h
+
+rm -f c2t.h.[12]


### PR DESCRIPTION
makeheader produces intermediate files c2t.h.1 and c2t.h.2. They don't seem to be needed later but neither makeheader nor `make clean` removes them and they aren't mentioned in .gitignore so they show up as untracked files in `git status`. The simplest fix seems to be to have makeheader delete the files itself when it's done with them.