### PR TITLE
Allow Makefile compiler to be set with CC variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,23 +20,23 @@ clean: testclean
 
 # nix
 bin/c2t: c2t.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t c2t.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t c2t.c -lm
 
 bin/c2t-96h: c2t-96h.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t-96h c2t-96h.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t-96h c2t-96h.c -lm
 
 # macos universal
 bin/c2t_x86: c2t.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target x86_64-apple-macos10.12 -o $@ c2t.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target x86_64-apple-macos10.12 -o $@ c2t.c -lm
 
 bin/c2t-96h_x86: c2t-96h.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target x86_64-apple-macos10.12 -o $@ c2t-96h.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target x86_64-apple-macos10.12 -o $@ c2t-96h.c -lm
 
 bin/c2t_arm: c2t.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target arm64-apple-macos11 -o $@ c2t.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target arm64-apple-macos11 -o $@ c2t.c -lm
 
 bin/c2t-96h_arm: c2t-96h.c c2t.h
-	gcc -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target arm64-apple-macos11 -o $@ c2t-96h.c -lm
+	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target arm64-apple-macos11 -o $@ c2t-96h.c -lm
 
 # windows
 bin/c2t.exe: c2t.c c2t.h


### PR DESCRIPTION
Instead of hardcoding "gcc", this allows the user to set the compiler with the typical CC environment variable, such as:

```
make CC=/path/to/my/clang
```

I initially also added a line `CC=gcc` at the top so as to not change the previous behavior. However `make` already provides a default value of "cc" for CC which is usually fine, since `cc` should be whatever the customary compiler is on a system. On macOS, since over a decade now, /usr/bin/gcc has not been gcc but rather a wrapper that calls clang (just as /usr/bin/cc does) and with which c2t appears to build fine. In fact, when building your macos targets, your Makefile doesn't even work with real gcc:

```
make macos CC=gcc-mp-11
...
gcc-mp-11 -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -target x86_64-apple-macos10.12 -o bin/c2t_x86 c2t.c -lm
gcc-mp-11: error: unrecognized command-line option '-target'
make: *** [bin/c2t_x86] Error 1
```

For these reasons I felt that using `make`'s default value of `CC=cc` was the way to go.